### PR TITLE
feat(card): add market value service with condition breakdown

### DIFF
--- a/src/application/use-cases/card/get-card-market-value.use-case.ts
+++ b/src/application/use-cases/card/get-card-market-value.use-case.ts
@@ -1,0 +1,19 @@
+import { TransactionRepository, MarketValueData } from "../../../domain/repositories/transaction.repository";
+import { CardRepository } from "../../../domain/repositories/card.repository";
+import { CustomError } from "../../../domain/errors/custom.error";
+
+export class GetCardMarketValueUseCase {
+  constructor(
+    private readonly transactionRepository: TransactionRepository,
+    private readonly cardRepository: CardRepository
+  ) {}
+
+  async execute(cardId: string): Promise<MarketValueData | null> {
+    // 1. Verify card exists (optional but good for error reporting)
+    const card = await this.cardRepository.findById(cardId);
+    if (!card) throw CustomError.notFound('Card not found');
+
+    // 2. Get market value from repository
+    return this.transactionRepository.getMarketValue(cardId);
+  }
+}

--- a/src/application/use-cases/index.ts
+++ b/src/application/use-cases/index.ts
@@ -3,6 +3,7 @@ export * from './card/get-card-by-id.use-case';
 export * from './card/create-card.use-case';
 export * from './card/update-card.use-case';
 export * from './card/delete-card.use-case';
+export * from './card/get-card-market-value.use-case';
 
 export * from './user/get-all-users.use-case';
 export * from './user/get-user-by-id.use-case';

--- a/src/domain/repositories/transaction.repository.ts
+++ b/src/domain/repositories/transaction.repository.ts
@@ -1,10 +1,16 @@
 import { TransactionEntity, TransactionStatus } from "../entities/transaction.entity";
 import { DbClient } from "../interfaces/db-client.interface";
 
+export interface MarketValueData {
+    globalAverage: number;
+    byCondition: { [condition: string]: number };
+}
+
 export interface TransactionRepository {
     create(transaction: Omit<TransactionEntity, 'id' | 'createdAt' | 'updatedAt'>, dbClient?: DbClient): Promise<TransactionEntity>;
     findById(id: string): Promise<TransactionEntity | null>;
     findAllByBuyer(buyerId: string): Promise<TransactionEntity[]>;
     findAllBySeller(sellerId: string): Promise<TransactionEntity[]>;
     updateStatus(id: string, status: TransactionStatus, dbClient?: DbClient): Promise<TransactionEntity>;
+    getMarketValue(cardId: string): Promise<MarketValueData | null>;
 }

--- a/src/infrastructure/repositories/pg-transaction.repository.ts
+++ b/src/infrastructure/repositories/pg-transaction.repository.ts
@@ -1,6 +1,6 @@
 import { db } from "../database/postgres/database";
 import { TransactionEntity, TransactionStatus } from "../../domain/entities/transaction.entity";
-import { TransactionRepository } from "../../domain/repositories/transaction.repository";
+import { TransactionRepository, MarketValueData } from "../../domain/repositories/transaction.repository";
 import { TransactionMapper } from "../mappers/transaction.mapper";
 import { DbClient } from "../../domain/interfaces/db-client.interface";
 
@@ -53,5 +53,43 @@ export class PostgresTransactionRepository implements TransactionRepository {
         const { rows } = await connection.query(query, [id, status]);
         if (rows.length === 0) throw new Error('Transaction not found');
         return TransactionMapper.toEntity(rows[0]);
+    }
+
+    async getMarketValue(cardId: string): Promise<MarketValueData | null> {
+        const conditionQuery = `
+            SELECT 
+                s.condition, 
+                AVG(t.total_price / t.quantity) as avg_price
+            FROM transactions t
+            JOIN sales s ON t.sale_id = s.id
+            WHERE s.card_id = $1 AND t.status = 'completed'
+            GROUP BY s.condition
+        `;
+
+        const globalQuery = `
+            SELECT AVG(t.total_price / t.quantity) as global_avg
+            FROM transactions t
+            JOIN sales s ON t.sale_id = s.id
+            WHERE s.card_id = $1 AND t.status = 'completed'
+        `;
+
+        const [conditionResult, globalResult] = await Promise.all([
+            db.query(conditionQuery, [cardId]),
+            db.query(globalQuery, [cardId])
+        ]);
+
+        if (conditionResult.rows.length === 0) return null;
+
+        const byCondition: { [condition: string]: number } = {};
+        conditionResult.rows.forEach(row => {
+            byCondition[row.condition] = parseFloat(row.avg_price);
+        });
+
+        const globalAverage = parseFloat(globalResult.rows[0].global_avg);
+
+        return {
+            globalAverage,
+            byCondition
+        };
     }
 }

--- a/src/infrastructure/web/controllers/card.controller.ts
+++ b/src/infrastructure/web/controllers/card.controller.ts
@@ -1,18 +1,21 @@
 import { Request, Response, NextFunction } from 'express';
 import { CardRepository } from '../../../domain/repositories/card.repository';
 import { TcgRepository } from '../../../domain/repositories/tcg.repository';
+import { TransactionRepository } from '../../../domain/repositories/transaction.repository';
 import {
   GetAllCardsUseCase,
   GetCardByIdUseCase,
   CreateCardUseCase,
   UpdateCardUseCase,
   DeleteCardUseCase,
+  GetCardMarketValueUseCase
 } from '../../../application/use-cases';
 
 export class CardController {
   constructor(
     private readonly cardRepository: CardRepository,
-    private readonly tcgRepository: TcgRepository
+    private readonly tcgRepository: TcgRepository,
+    private readonly transactionRepository: TransactionRepository
   ) {}
 
   getAll = async (_req: Request, res: Response, next: NextFunction) => {
@@ -61,6 +64,19 @@ export class CardController {
     try {
       await new DeleteCardUseCase(this.cardRepository).execute(String(req.params['id']));
       res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
+  };
+
+  getMarketValue = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const data = await new GetCardMarketValueUseCase(
+        this.transactionRepository,
+        this.cardRepository
+      ).execute(String(req.params['id']));
+      
+      res.json(data);
     } catch (err) {
       next(err);
     }

--- a/src/infrastructure/web/routes/card.routes.ts
+++ b/src/infrastructure/web/routes/card.routes.ts
@@ -1,15 +1,17 @@
 import { Router } from 'express';
 import { CardController } from '../controllers/card.controller';
-import { PostgresCardRepository } from '../../repositories';
+import { PostgresCardRepository, PostgresTransactionRepository } from '../../repositories';
 import { TcgSdkRepository } from '../../repositories/tcg-sdk.repository';
 
 const router = Router();
 const cardRepository = new PostgresCardRepository();
+const transactionRepository = new PostgresTransactionRepository();
 const tcgRepository = new TcgSdkRepository();
-const controller = new CardController(cardRepository, tcgRepository);
+const controller = new CardController(cardRepository, tcgRepository, transactionRepository);
 
 router.get('/', controller.getAll);
 router.get('/:id', controller.getById);
+router.get('/:id/market-value', controller.getMarketValue);
 router.post('/', controller.create);
 router.put('/:id', controller.update);
 router.delete('/:id', controller.delete);


### PR DESCRIPTION
- Implement `getMarketValue` in `PostgresTransactionRepository` using completed transactions.
- Create `GetCardMarketValueUseCase` to calculate global and per-condition averages.
- Expose `GET /cards/:id/market-value` endpoint in `CardController` and `card.routes.ts`.
- Support statistically accurate averages and handle cases with no transaction data by returning `null`.