### PR TITLE
fix: resolve repository exports and missing entity imports

### DIFF
--- a/src/infrastructure/repositories/index.ts
+++ b/src/infrastructure/repositories/index.ts
@@ -2,4 +2,7 @@ export * from './pg-card.repository';
 export * from './pg-user.repository';
 export * from './pg-album.repository';
 export * from './pg-page.repository';
+export * from './pg-sale.repository';
+export * from './pg-transaction.repository';
+export * from './pg-pokemon.repository';
 export * from './tcg-sdk.repository';

--- a/src/infrastructure/services/pokeapi.service.ts
+++ b/src/infrastructure/services/pokeapi.service.ts
@@ -1,3 +1,4 @@
+import { PokemonEntity } from "../../domain/entities/pokemon.entity";
 import { PokemonExternalService } from "../../domain/interfaces/pokemon-external.service";
 
 export class PokeApiService implements PokemonExternalService {


### PR DESCRIPTION
- Export PostgresTransactionRepository, PostgresSaleRepository, and PostgresPokemonRepository from infrastructure/repositories/index.ts.
- Add missing PokemonEntity import to PokeApiService.
- Fix TSError preventing server startup on new branch.